### PR TITLE
Drop PostgreSQL 7 compatibility

### DIFF
--- a/pg_dumpacl.c
+++ b/pg_dumpacl.c
@@ -525,11 +525,11 @@ connectDatabase(const char *dbname, const char *connection_string,
 	my_version = PG_VERSION_NUM;
 
 	/*
-	 * We allow the server to be back to 7.0, and up to any minor release of
+	 * We allow the server to be back to 8.0, and up to any minor release of
 	 * our own major version.  (See also version check in pg_dump.c.)
 	 */
 	if (my_version != server_version
-		&& (server_version < 70000 ||
+		&& (server_version < 80000 ||
 			(server_version / 100) > (my_version / 100)))
 	{
 		fprintf(stderr, _("server version: %s; %s version: %s\n"),


### PR DESCRIPTION
Drop PostgreSQL 7.X compatibility (change done in PostgreSQL 10).