### PR TITLE
PGDATABASE environment variable is now used as fallback value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
           ./fixture.sh
           ./pg_dumpacl -d db0
           ./pg_dumpacl --all
+          export PGDATABASE=db0
+          ./pg_dumpacl
 
   0-rpm-centos7:
     working_directory: /tmp/cci


### PR DESCRIPTION
In case the database is not specified using the -d option or in the connection string, we use the PGDATABASE environment variable as database name to dump.

Add a test using the env variable PGDATABASE in the circleci.




